### PR TITLE
Fix install-bin bugs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ install: install-bin install-completions
 install-bin:
 	gzip -c pdd.1 > pdd.1.gz
 	install -Dm755 pdd $(BINDIR)/pdd
-	install -Dm644 pdd.1.gz $(MANDIR)
-	install -Dm644 README.md $(DOCDIR)
+	install -Dm644 pdd.1.gz $(MANDIR)/pdd.1.gz
+	install -Dm644 README.md $(DOCDIR)/README.md
 	rm -f pdd.1.gz
 
 install-completions: install-bash-completion install-zsh-completion install-fish-completion


### PR DESCRIPTION
The `install -D` command will "create all leading components of DEST except the last". So we need to specifically define the file path.


Otherwise, `install -D` will not create the `doc/pdd` or `man/pdd` folder.

```
usr
│  
└── share
    ├── doc
    │   └── pdd
    ├── man
        └── man1.gz
...
```